### PR TITLE
chore: publish documentation after npm package

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,6 +22,7 @@ jobs:
         run: yarn release
 
   publish-docs:
+    needs: publish-package
     name: Publish documentation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Ensures the publish-docs job runs after the publish-package job has ran. This is required so that the changelog is updated before it's published to the vuepress site.